### PR TITLE
Fix typing issues in miru

### DIFF
--- a/miru/__init__.py
+++ b/miru/__init__.py
@@ -23,6 +23,7 @@ SOFTWARE.
 """
 
 from .button import *
+from .interaction import *
 from .item import *
 from .select import *
 from .view import *

--- a/miru/button.py
+++ b/miru/button.py
@@ -26,16 +26,28 @@ from __future__ import annotations
 
 import inspect
 import os
+from typing import TYPE_CHECKING
+from typing import Any
 from typing import Callable
 from typing import Optional
+from typing import TypeVar
 from typing import Union
 
 import hikari
 
+from .item import DecoratedItem
 from .item import Item
 
+if TYPE_CHECKING:
+    from .view import View
 
-class Button(Item):
+ViewT = TypeVar("ViewT", bound="View")
+CallableT = TypeVar("CallableT", bound=Callable[..., Any])
+
+__all__ = ["Button", "button"]
+
+
+class Button(Item[ViewT]):
     """
     A view component representing a button.
     """
@@ -175,26 +187,26 @@ def button(
     style: hikari.ButtonStyle = hikari.ButtonStyle.PRIMARY,
     emoji: Optional[Union[str, hikari.Emoji]] = None,
     row: Optional[int] = None,
-    disabled: Optional[bool] = False,
-) -> Callable[[Callable], Callable]:
+    disabled: bool = False,
+) -> Callable[[CallableT], CallableT]:
     """
     A decorator to transform a function into a Discord UI Button's callback. This must be inside a subclass of View.
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[..., Any]) -> Any:
         if not inspect.iscoroutinefunction(func):
             raise TypeError("button must decorate coroutine function.")
 
-        func._view_item_type = Button
-        func._view_item_data = {
-            "label": label,
-            "custom_id": custom_id,
-            "style": style,
-            "emoji": emoji,
-            "row": row,
-            "disabled": disabled,
-            "url": None,
-        }
-        return func
+        item: Button[Any] = Button(
+            label=label,
+            custom_id=custom_id,
+            style=style,
+            emoji=emoji,
+            row=row,
+            disabled=disabled,
+            url=None,
+        )
+
+        return DecoratedItem(item, func)
 
     return decorator

--- a/miru/interaction.py
+++ b/miru/interaction.py
@@ -9,21 +9,22 @@ if typing.TYPE_CHECKING:
     from hikari import messages
 
 
+__all__ = ["Interaction"]
+
+
 class Interaction(hikari.ComponentInteraction):
     """
     Represents a component interaction on Discord. Has additional short-hand methods for ease-of-use.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._issued_response: bool = False
+    _issued_response: bool = False
 
     @classmethod
-    def from_hikari(self, interaction: hikari.ComponentInteraction) -> Interaction:
+    def from_hikari(cls, interaction: hikari.ComponentInteraction) -> Interaction:
         """
         Create a new Interaction object from a hikari.ComponentInteraction. This should be rarely used.
         """
-        return Interaction(
+        return cls(
             channel_id=interaction.channel_id,
             component_type=interaction.component_type,
             custom_id=interaction.custom_id,
@@ -41,12 +42,12 @@ class Interaction(hikari.ComponentInteraction):
         )
 
     @functools.wraps(hikari.ComponentInteraction.create_initial_response)
-    async def create_initial_response(self, *args, **kwargs) -> None:
+    async def create_initial_response(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         await super().create_initial_response(*args, **kwargs)
         self._issued_response = True
 
     @functools.wraps(hikari.ComponentInteraction.execute)
-    async def send_message(self, *args, **kwargs) -> None:
+    async def send_message(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """
         Short-hand method to send a message response to the interaction
         """
@@ -56,7 +57,7 @@ class Interaction(hikari.ComponentInteraction):
             await self.create_initial_response(hikari.ResponseType.MESSAGE_CREATE, *args, **kwargs)
 
     @functools.wraps(hikari.ComponentInteraction.execute)
-    async def edit_message(self, *args, **kwargs) -> None:
+    async def edit_message(self, *args: typing.Any, **kwargs: typing.Any) -> None:  # type: ignore
         """
         Short-hand method for editing the message the component is attached to.
         """

--- a/miru/item.py
+++ b/miru/item.py
@@ -85,7 +85,7 @@ class Item(abc.ABC, Generic[ViewT]):
     @property
     def view(self) -> ViewT:
         """
-        The view this item is attached to, if any.
+        The view this item is attached to. Raises AttributeError if the item is not attached to a view.
         """
         if not self._view:
             raise AttributeError(f"{self.__class__.__name__} hasn't been attached to a view yet")

--- a/miru/item.py
+++ b/miru/item.py
@@ -21,13 +21,18 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+
 from __future__ import annotations
 
 import abc
-import os
 from abc import abstractmethod
+from functools import partial
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Generic
 from typing import Optional
+from typing import TypeVar
 
 import hikari
 
@@ -36,14 +41,18 @@ from .interaction import Interaction
 if TYPE_CHECKING:
     from .view import View
 
+ViewT = TypeVar("ViewT", bound="View")
 
-class Item(abc.ABC):
+__all__ = ["Item", "DecoratedItem"]
+
+
+class Item(abc.ABC, Generic[ViewT]):
     """
     An abstract base class for view components. Cannot be directly instantiated.
     """
 
     def __init__(self) -> None:
-        self._view: Optional[View] = None
+        self._view: Optional[ViewT] = None
         self._row: Optional[int] = None
         self._width: int = 1
         self._rendered_row: Optional[int] = None  # Where it actually ends up when rendered by Discord
@@ -74,10 +83,13 @@ class Item(abc.ABC):
         return self._width
 
     @property
-    def view(self) -> Optional[View]:
+    def view(self) -> ViewT:
         """
         The view this item is attached to, if any.
         """
+        if not self._view:
+            raise AttributeError(f"{self.__class__.__name__} hasn't been attached to a view yet")
+
         return self._view
 
     @property
@@ -120,3 +132,19 @@ class Item(abc.ABC):
         Called on an item to refresh its internal data.
         """
         pass
+
+
+class DecoratedItem:
+    """A partial item made using a decorator"""
+
+    def __init__(self, item: Item[Any], callback: Callable[..., Any]) -> None:
+        self.item = item
+        self.callback = callback
+
+    def build(self, view: ViewT) -> Item[ViewT]:
+        self.item.callback = partial(self.callback, view, self.item)  # type: ignore[assignment]
+
+        return self.item
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.callback(*args, **kwargs)

--- a/miru/item.py
+++ b/miru/item.py
@@ -146,5 +146,9 @@ class DecoratedItem:
 
         return self.item
 
+    @property
+    def name(self) -> str:
+        return self.callback.__name__
+
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.callback(*args, **kwargs)

--- a/miru/view.py
+++ b/miru/view.py
@@ -21,23 +21,27 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-
 from __future__ import annotations
 
 import asyncio
 import itertools
 import sys
 import traceback
-from functools import partial
-from typing import Callable
+from typing import Any
 from typing import ClassVar
 from typing import List
 from typing import Optional
+from typing import TypeVar
 
 import hikari
 
 from .interaction import Interaction
+from .item import DecoratedItem
 from .item import Item
+
+ViewT = TypeVar("ViewT", bound="View")
+
+__all__ = ["View"]
 
 
 class _Weights:
@@ -45,11 +49,11 @@ class _Weights:
     Calculate the position of an item based on it's width, and keep track of item positions
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
 
         self._weights = [0, 0, 0, 0, 0]
 
-    def add_item(self, item: Item) -> None:
+    def add_item(self, item: Item[Any]) -> None:
         if item.row is not None:
             if item.width + self._weights[item.row] > 5:
                 raise ValueError(f"Item does not fit on row {item.row}!")
@@ -63,7 +67,7 @@ class _Weights:
                     item._rendered_row = row + 1
                     break
 
-    def remove_item(self, item: Item) -> None:
+    def remove_item(self, item: Item[Any]) -> None:
         if item._row:
             self._weights[item._row] -= item.width
             item._rendered_row = None
@@ -78,17 +82,17 @@ class View:
     """
 
     persistent_views: List["View"] = []  # List of all currently active persistent views
-    _view_children: ClassVar[List["Callable"]] = []  # Decorated callbacks that need to be turned into items
+    _view_children: ClassVar[List[DecoratedItem]] = []  # Decorated callbacks that need to be turned into items
 
     def __init_subclass__(cls) -> None:
         """
         Get decorated callbacks
         """
-        children: List[Callable] = []
+        children: List[DecoratedItem] = []
         for base_cls in reversed(cls.mro()):
-            for func in base_cls.__dict__.values():
-                if hasattr(func, "_view_item_type"):
-                    children.append(func)
+            for value in base_cls.__dict__.values():
+                if isinstance(value, DecoratedItem):
+                    children.append(value)
 
         if len(children) > 25:
             raise ValueError("View cannot have more than 25 components attached.")
@@ -103,7 +107,7 @@ class View:
         autodefer: Optional[bool] = True,
     ) -> None:
         self._timeout: Optional[float] = float(timeout) if timeout else None
-        self._children: List[Item] = []
+        self._children: List[Item[Any]] = []
         self._app: hikari.GatewayBot = app
         self._autodefer: Optional[bool] = autodefer
         self._message: Optional[hikari.Message] = None
@@ -112,9 +116,8 @@ class View:
         self._stopped: asyncio.Event = asyncio.Event()
         self._listener_task: Optional[asyncio.Task[None]] = None
 
-        for callable in self._view_children:  # Sort and instantiate decorated callbacks
-            item = callable._view_item_type(**callable._view_item_data)
-            item.callback = partial(callable, self, item)
+        for decorated_item in self._view_children:  # Sort and instantiate decorated callbacks
+            item = decorated_item.build(self)
             self.add_item(item)
             setattr(self, callable.__name__, item)
 
@@ -140,7 +143,7 @@ class View:
         return self._timeout
 
     @property
-    def children(self) -> List[Item]:
+    def children(self: ViewT) -> List[Item[ViewT]]:
         """
         A list of all items attached to the view.
         """
@@ -167,7 +170,7 @@ class View:
         """
         return self._message
 
-    def add_item(self, item: Item) -> None:
+    def add_item(self, item: Item[Any]) -> None:
         """Adds a new item to the view."""
 
         if len(self.children) > 25:
@@ -181,7 +184,7 @@ class View:
         item._view = self
         self.children.append(item)
 
-    def remove_item(self, item: Item) -> None:
+    def remove_item(self, item: Item[Any]) -> None:
         """Removes the specified item from the view."""
         try:
             self.children.remove(item)
@@ -224,7 +227,10 @@ class View:
         return True
 
     async def on_error(
-        self, error: Exception, item: Optional[Item] = None, interaction: Optional[Interaction] = None
+        self: ViewT,
+        error: Exception,
+        item: Optional[Item[ViewT]] = None,
+        interaction: Optional[Interaction] = None,
     ) -> None:
         """
         Called when an error occurs in a callback function or the built-in timeout function.
@@ -246,7 +252,7 @@ class View:
         if self.is_persistent:
             View.persistent_views.remove(self)
 
-    async def _handle_callback(self, item: Item, interaction: Interaction) -> None:
+    async def _handle_callback(self: ViewT, item: Item[ViewT], interaction: Interaction) -> None:
         """
         Handle the callback of a view item. Seperate task in case the view is stopped in the callback.
         """

--- a/miru/view.py
+++ b/miru/view.py
@@ -120,7 +120,7 @@ class View:
         for decorated_item in self._view_children:  # Sort and instantiate decorated callbacks
             item = decorated_item.build(self)
             self.add_item(item)
-            setattr(self, callable.__name__, item)
+            setattr(self, decorated_item.name, item)
 
         if len(self.children) > 25:
             raise ValueError("View cannot have more than 25 components attached.")


### PR DESCRIPTION
Some internal changes had to be made to make miru type-safe

# Changes
- make items generic (`item.view` can now be given attributes)
- make `@button` and `@select` be typed to return the same function that was given
  - A possible alternative is returning the actual type, happy to hear your opinions on this one!
- added all missing `typing.Any` and `None` annotations where they were forgotten