### PR TITLE
Fix a few bugs and inconsistencies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,6 @@
 name: Run checks
 
-on: push
+on: [push, pull_request]
 
 jobs:
   formatting:

--- a/docs/source/changelogs/v1.rst
+++ b/docs/source/changelogs/v1.rst
@@ -6,6 +6,15 @@ These are all the changelogs for stable releases of hikari-miru (version 1.0.0 t
 
 ----
 
+Version 1.1.0
+=============
+
+- Annotate ``miru.button()`` and ``miru.select()`` to return their respective objects.
+
+- Make ``colorama`` be an optional dependency exclusive to win32.
+
+- Add ``miru.unload()`` to unload miru and stop all bound views.
+
 Version 1.0.0
 =============
 

--- a/docs/source/changelogs/v1.rst
+++ b/docs/source/changelogs/v1.rst
@@ -15,11 +15,9 @@ Version 1.1.0
 
 - Fix a bug where ``miru.Context.edit_response()`` would not work correctly after initial response.
 
-- No longer use explicit submodules unless they are exported in context type signatures
+- No longer use explicit submodules unless they are exported in context type signatures.
 
-- Ignore 3rd party libraries with missing stubs
-
-- Make colorama dependency an optional Windows-only dependency
+- Make colorama an optional Windows-only dependency.
 
 Thanks to `sadru <https://github.com/thesadru>`_ for help with this release.
 

--- a/docs/source/changelogs/v1.rst
+++ b/docs/source/changelogs/v1.rst
@@ -9,11 +9,19 @@ These are all the changelogs for stable releases of hikari-miru (version 1.0.0 t
 Version 1.1.0
 =============
 
+- Add ``miru.unload()`` to unload miru and remove the application reference.
+
 - Annotate ``miru.button()`` and ``miru.select()`` to return their respective objects.
 
-- Make ``colorama`` be an optional dependency exclusive to win32.
+- Fix a bug where ``miru.Context.edit_response()`` would not work correctly after initial response.
 
-- Add ``miru.unload()`` to unload miru and stop all bound views.
+- No longer use explicit submodules unless they are exported in context type signatures
+
+- Ignore 3rd party libraries with missing stubs
+
+- Make colorama dependency an optional Windows-only dependency
+
+Thanks to `sadru <https://github.com/thesadru>`_ for help with this release.
 
 Version 1.0.0
 =============

--- a/docs/source/changelogs/v1.rst
+++ b/docs/source/changelogs/v1.rst
@@ -19,6 +19,8 @@ Version 1.1.0
 
 - Make colorama an optional Windows-only dependency.
 
+- Allow entire message objects in ``miru.start_listener()``.
+
 Thanks to `sadru <https://github.com/thesadru>`_ for help with this release.
 
 Version 1.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,8 +25,12 @@ author = "HyperGH"
 
 with open("../../miru/__init__.py") as fp:
     file = fp.read()
-version = re.search(r"__version__ = \"([^\"]+)", file).group(1)
-release = version
+
+if _match := re.search(r"__version__ = \"([^\"]+)", file):
+    version = _match.group(1)
+    release = version
+else:
+    raise RuntimeError("Improperly formatted miru/__init__.py file")
 
 master_doc = "index"
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -27,7 +27,11 @@ This is what a basic component menu looks like with miru:
 
         # Define a new Select menu with two options
         @miru.select(
-            placeholder="Select me!", options=[miru.SelectOption(label="Option 1"), miru.SelectOption(label="Option 2")]
+            placeholder="Select me!",
+            options=[
+                miru.SelectOption(label="Option 1"),
+                miru.SelectOption(label="Option 2"),
+            ],
         )
         async def basic_select(self, select: miru.Select, ctx: miru.Context) -> None:
             await ctx.respond(f"You've chosen {select.values[0]}!")

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -32,7 +32,11 @@ class BasicView(miru.View):
 
     # Define a new Select menu with two options
     @miru.select(
-        placeholder="Select me!", options=[miru.SelectOption(label="Option 1"), miru.SelectOption(label="Option 2")]
+        placeholder="Select me!", 
+        options=[
+            miru.SelectOption(label="Option 1"), 
+            miru.SelectOption(label="Option 2"),
+        ],
     )
     async def basic_select(self, select: miru.Select, ctx: miru.Context) -> None:
         await ctx.respond(f"You've chosen {select.values[0]}!")

--- a/miru/__init__.py
+++ b/miru/__init__.py
@@ -28,4 +28,4 @@ from .select import *
 from .traits import *
 from .view import *
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"

--- a/miru/__main__.py
+++ b/miru/__main__.py
@@ -25,25 +25,31 @@ import platform
 import sys
 
 import hikari
-from colorama import Fore
-from colorama import init
 
 import miru
 
 # Support color on Windows
-init()
-system_details = (
-    f"{platform.uname().system} {platform.uname().machine} ({platform.uname().node}) - {platform.uname().release}"
-)
+if sys.platform == "win32":
+    import colorama
+
+    colorama.init()
+
+
+CYAN = "\x1b[36m"
+WHITE = "\x1b[37m"
+LIGHTCYAN = "\x1b[96m"
+
+uname = platform.uname()
+system_details = f"{uname.system} {uname.machine} ({uname.node}) - {uname.release}"
 python_details = f"{platform.python_implementation()} {platform.python_version()} ({platform.python_compiler()})"
 
 sys.stderr.write(
-    f"""{Fore.LIGHTCYAN_EX}hikari-miru - package information
-{Fore.WHITE}----------------------------------
-{Fore.CYAN}Miru version: {Fore.WHITE}{miru.__version__}
-{Fore.CYAN}Install path: {Fore.WHITE}{os.path.abspath(os.path.dirname(__file__))}
-{Fore.CYAN}Hikari version: {Fore.WHITE}{hikari.__version__}
-{Fore.CYAN}Install path: {Fore.WHITE}{os.path.abspath(os.path.dirname(hikari.__file__))}
-{Fore.CYAN}Python: {Fore.WHITE}{python_details}
-{Fore.CYAN}System: {Fore.WHITE}{system_details}\n\n"""
+    f"""{LIGHTCYAN}hikari-miru - package information
+{WHITE}----------------------------------
+{CYAN}Miru version: {WHITE}{miru.__version__}
+{CYAN}Install path: {WHITE}{os.path.abspath(os.path.dirname(__file__))}
+{CYAN}Hikari version: {WHITE}{hikari.__version__}
+{CYAN}Install path: {WHITE}{os.path.abspath(os.path.dirname(hikari.__file__))}
+{CYAN}Python: {WHITE}{python_details}
+{CYAN}System: {WHITE}{system_details}\n\n"""
 )

--- a/miru/__main__.py
+++ b/miru/__main__.py
@@ -25,7 +25,7 @@ import platform
 import sys
 
 import hikari
-from colorama import Fore  # type: ignore[import]
+from colorama import Fore
 from colorama import init
 
 import miru
@@ -43,7 +43,7 @@ sys.stderr.write(
 {Fore.CYAN}Miru version: {Fore.WHITE}{miru.__version__}
 {Fore.CYAN}Install path: {Fore.WHITE}{os.path.abspath(os.path.dirname(__file__))}
 {Fore.CYAN}Hikari version: {Fore.WHITE}{hikari.__version__}
-{Fore.CYAN}Install path: {Fore.WHITE}{os.path.abspath(os.path.dirname(hikari._about.__file__))}
+{Fore.CYAN}Install path: {Fore.WHITE}{os.path.abspath(os.path.dirname(hikari.__file__))}
 {Fore.CYAN}Python: {Fore.WHITE}{python_details}
 {Fore.CYAN}System: {Fore.WHITE}{system_details}\n\n"""
 )

--- a/miru/button.py
+++ b/miru/button.py
@@ -37,10 +37,10 @@ from .item import DecoratedItem
 from .item import Item
 
 if TYPE_CHECKING:
+    from .context import Context
     from .view import View
 
 ViewT = TypeVar("ViewT", bound="View")
-CallableT = TypeVar("CallableT", bound=Callable[..., Any])
 
 __all__ = ["Button", "button"]
 
@@ -202,7 +202,7 @@ def button(
     emoji: Optional[Union[str, hikari.Emoji]] = None,
     row: Optional[int] = None,
     disabled: bool = False,
-) -> Callable[[CallableT], CallableT]:
+) -> Callable[[Callable[[ViewT, Button[ViewT], Context], Any]], Button[ViewT]]:
     """A decorator to transform a coroutine function into a Discord UI Button's callback.
     This must be inside a subclass of View.
 

--- a/miru/context.py
+++ b/miru/context.py
@@ -110,25 +110,21 @@ class Context:
 
     async def respond(
         self,
-        content: hikari.undefined.UndefinedOr[typing.Any] = hikari.undefined.UNDEFINED,
+        content: hikari.UndefinedOr[typing.Any] = hikari.UNDEFINED,
         *,
-        flags: typing.Union[int, hikari.MessageFlag, hikari.undefined.UndefinedType] = hikari.undefined.UNDEFINED,
-        tts: hikari.undefined.UndefinedOr[bool] = hikari.undefined.UNDEFINED,
-        component: hikari.undefined.UndefinedOr[
-            hikari.api.special_endpoints.ComponentBuilder
-        ] = hikari.undefined.UNDEFINED,
-        components: hikari.undefined.UndefinedOr[
-            typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]
-        ] = hikari.undefined.UNDEFINED,
-        embed: hikari.undefined.UndefinedOr[hikari.Embed] = hikari.undefined.UNDEFINED,
-        embeds: hikari.undefined.UndefinedOr[typing.Sequence[hikari.Embed]] = hikari.undefined.UNDEFINED,
-        mentions_everyone: hikari.undefined.UndefinedOr[bool] = hikari.undefined.UNDEFINED,
-        user_mentions: hikari.undefined.UndefinedOr[
-            typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.PartialUser], bool]
-        ] = hikari.undefined.UNDEFINED,
-        role_mentions: hikari.undefined.UndefinedOr[
-            typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.PartialRole], bool]
-        ] = hikari.undefined.UNDEFINED,
+        flags: typing.Union[int, hikari.MessageFlag, hikari.UndefinedType] = hikari.UNDEFINED,
+        tts: hikari.UndefinedOr[bool] = hikari.UNDEFINED,
+        component: hikari.UndefinedOr[hikari.api.ComponentBuilder] = hikari.UNDEFINED,
+        components: hikari.UndefinedOr[typing.Sequence[hikari.api.ComponentBuilder]] = hikari.UNDEFINED,
+        embed: hikari.UndefinedOr[hikari.Embed] = hikari.UNDEFINED,
+        embeds: hikari.UndefinedOr[typing.Sequence[hikari.Embed]] = hikari.UNDEFINED,
+        mentions_everyone: hikari.UndefinedOr[bool] = hikari.UNDEFINED,
+        user_mentions: hikari.UndefinedOr[
+            typing.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]
+        ] = hikari.UNDEFINED,
+        role_mentions: hikari.UndefinedOr[
+            typing.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]
+        ] = hikari.UNDEFINED,
     ) -> None:
         """Short-hand method to respond to the interaction this context represents.
 
@@ -152,9 +148,9 @@ class Context:
             A sequence of embeds to add to this message.
         mentions_everyone : undefined.UndefinedOr[bool], optional
             If True, mentioning @everyone will be allowed.
-        user_mentions : undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.PartialUser], bool]], optional
+        user_mentions : undefined.UndefinedOr[typing.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]], optional
             The set of allowed user mentions in this message. Set to True to allow all.
-        role_mentions : undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.PartialRole], bool]], optional
+        role_mentions : undefined.UndefinedOr[typing.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]], optional
             The set of allowed role mentions in this message. Set to True to allow all.
         flags : typing.Union[undefined.UndefinedType, int, hikari.MessageFlag], optional
             Message flags that should be included with this message.
@@ -189,25 +185,21 @@ class Context:
 
     async def edit_response(
         self,
-        content: hikari.undefined.UndefinedOr[typing.Any] = hikari.undefined.UNDEFINED,
+        content: hikari.UndefinedOr[typing.Any] = hikari.UNDEFINED,
         *,
-        flags: typing.Union[int, hikari.MessageFlag, hikari.undefined.UndefinedType] = hikari.undefined.UNDEFINED,
-        tts: hikari.undefined.UndefinedOr[bool] = hikari.undefined.UNDEFINED,
-        component: hikari.undefined.UndefinedOr[
-            hikari.api.special_endpoints.ComponentBuilder
-        ] = hikari.undefined.UNDEFINED,
-        components: hikari.undefined.UndefinedOr[
-            typing.Sequence[hikari.api.special_endpoints.ComponentBuilder]
-        ] = hikari.undefined.UNDEFINED,
-        embed: hikari.undefined.UndefinedOr[hikari.Embed] = hikari.undefined.UNDEFINED,
-        embeds: hikari.undefined.UndefinedOr[typing.Sequence[hikari.Embed]] = hikari.undefined.UNDEFINED,
-        mentions_everyone: hikari.undefined.UndefinedOr[bool] = hikari.undefined.UNDEFINED,
-        user_mentions: hikari.undefined.UndefinedOr[
-            typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.PartialUser], bool]
-        ] = hikari.undefined.UNDEFINED,
-        role_mentions: hikari.undefined.UndefinedOr[
-            typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.PartialRole], bool]
-        ] = hikari.undefined.UNDEFINED,
+        flags: typing.Union[int, hikari.MessageFlag, hikari.UndefinedType] = hikari.UNDEFINED,
+        tts: hikari.UndefinedOr[bool] = hikari.UNDEFINED,
+        component: hikari.UndefinedOr[hikari.api.ComponentBuilder] = hikari.UNDEFINED,
+        components: hikari.UndefinedOr[typing.Sequence[hikari.api.ComponentBuilder]] = hikari.UNDEFINED,
+        embed: hikari.UndefinedOr[hikari.Embed] = hikari.UNDEFINED,
+        embeds: hikari.UndefinedOr[typing.Sequence[hikari.Embed]] = hikari.UNDEFINED,
+        mentions_everyone: hikari.UndefinedOr[bool] = hikari.UNDEFINED,
+        user_mentions: hikari.UndefinedOr[
+            typing.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]
+        ] = hikari.UNDEFINED,
+        role_mentions: hikari.UndefinedOr[
+            typing.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]
+        ] = hikari.UNDEFINED,
     ) -> None:
         """A short-hand method to edit the message belonging to this interaction.
 
@@ -231,9 +223,9 @@ class Context:
             A sequence of embeds to add to this message.
         mentions_everyone : undefined.UndefinedOr[bool], optional
             If True, mentioning @everyone will be allowed.
-        user_mentions : undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.PartialUser], bool]], optional
+        user_mentions : undefined.UndefinedOr[typing.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]], optional
             The set of allowed user mentions in this message. Set to True to allow all.
-        role_mentions : undefined.UndefinedOr[typing.Union[hikari.snowflakes.SnowflakeishSequence[hikari.PartialRole], bool]], optional
+        role_mentions : undefined.UndefinedOr[typing.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]], optional
             The set of allowed role mentions in this message. Set to True to allow all.
         flags : typing.Union[undefined.UndefinedType, int, hikari.MessageFlag], optional
             Message flags that should be included with this message.
@@ -244,8 +236,7 @@ class Context:
             The interaction was already responded to.
         """
         if self.interaction._issued_response:
-            self.interaction.edit_message(
-                self.interaction.message,
+            await self.interaction.edit_initial_response(
                 content,
                 component=component,
                 components=components,
@@ -255,20 +246,20 @@ class Context:
                 user_mentions=user_mentions,
                 role_mentions=role_mentions,
             )
-
-        await self.interaction.create_initial_response(
-            hikari.ResponseType.MESSAGE_UPDATE,
-            content,
-            component=component,
-            components=components,
-            tts=tts,
-            embed=embed,
-            embeds=embeds,
-            mentions_everyone=mentions_everyone,
-            user_mentions=user_mentions,
-            role_mentions=role_mentions,
-            flags=flags,
-        )
+        else:
+            await self.interaction.create_initial_response(
+                hikari.ResponseType.MESSAGE_UPDATE,
+                content,
+                component=component,
+                components=components,
+                tts=tts,
+                embed=embed,
+                embeds=embeds,
+                mentions_everyone=mentions_everyone,
+                user_mentions=user_mentions,
+                role_mentions=role_mentions,
+                flags=flags,
+            )
 
     async def defer(self, flags: typing.Union[int, hikari.MessageFlag, None] = None) -> None:
         """Short-hand method to defer an interaction response. Raises RuntimeError if the interaction was already responded to.

--- a/miru/select.py
+++ b/miru/select.py
@@ -38,10 +38,10 @@ from .item import DecoratedItem
 from .item import Item
 
 if TYPE_CHECKING:
+    from .context import Context
     from .view import View
 
 ViewT = TypeVar("ViewT", bound="View")
-CallableT = TypeVar("CallableT", bound=Callable[..., Any])
 
 __all__ = ["SelectOption", "Select", "select"]
 
@@ -249,7 +249,7 @@ def select(
     max_values: int = 1,
     disabled: bool = False,
     row: Optional[int] = None,
-) -> Callable[[CallableT], CallableT]:
+) -> Callable[[Callable[[ViewT, Select[ViewT], Context], Any]], Select[ViewT]]:
     """
     A decorator to transform a function into a Discord UI SelectMenu's callback. This must be inside a subclass of View.
     """

--- a/miru/traits.py
+++ b/miru/traits.py
@@ -32,5 +32,3 @@ class ViewsAware(hikari.RESTAware, hikari.EventManagerAware, hikari.CacheAware, 
     """
     A trait that implements RESTAware, EventManagerAware and CacheAware.
     """
-
-    pass

--- a/miru/view.py
+++ b/miru/view.py
@@ -440,13 +440,13 @@ class View:
         """
         await asyncio.wait_for(self._stopped.wait(), timeout=None)
 
-    def start_listener(self, message_id: Optional[int] = None) -> None:
+    def start_listener(self, message: Optional[hikari.SnowflakeishOr[hikari.PartialMessage]] = None) -> None:
         """Re-registers a persistent view for listening after an application restart.
         Specify message_id to create a bound persistent view that can be edited afterwards.
 
         Parameters
         ----------
-        message_id : Optional[int], optional
+        message: Optional[hikari.SnowflakeishOr[hikari.PartialMessage]], optional
             If provided, the persistent view will be bound to this message, and if the
             message is edited with a new view, that will be taken into account.
             Unbound views do not support message editing with additional views.
@@ -459,12 +459,15 @@ class View:
         if not self.is_persistent:
             raise ValueError("This can only be used on persistent views.")
 
+        message_id = hikari.Snowflake(message) if message else None
+
         if message_id:
             self._message_id = message_id
 
             # Handle replacement of bound views on message edit
             if message_id in View._views.keys():
                 View._views[message_id].stop()
+
             View._views[message_id] = self
 
         self._listener_task = asyncio.create_task(self._listen_for_events(message_id))
@@ -492,6 +495,7 @@ class View:
         # Handle replacement of view on message edit
         if message.id in View._views.keys():
             View._views[message.id].stop()
+
         View._views[message.id] = self
 
 

--- a/miru/view.py
+++ b/miru/view.py
@@ -46,7 +46,7 @@ from .traits import ViewsAware
 
 ViewT = TypeVar("ViewT", bound="View")
 
-__all__ = ["View", "load"]
+__all__ = ["View", "load", "unload"]
 
 
 class _Weights(Generic[ViewT]):
@@ -517,3 +517,15 @@ def load(bot: ViewsAware) -> None:
         raise TypeError(f"Expected type with trait ViewsAware for parameter bot, not {type(bot)}")
 
     View._app = bot
+
+
+def unload() -> None:
+    """Unload miru and remove the current running application from it.
+
+    !!! warning
+        Unbound persistent views should be stopped manually.
+    """
+    for message, view in View._views.items():
+        view.stop()
+
+    View._app = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,10 @@ warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
+# dependency management (install stubs or fallback to Any)
+install_types = true
+non_interactive = true
+ignore_missing_imports = true
+
 [tool.pyright]
 exclude = ["examples"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 hikari>=2.0.0.dev106
-colorama

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
     extras_require={
+        ':sys_platform=="win32"': ["colorama"],
         "docs": parse_requirements_file("doc_requirements.txt"),
     },
     python_requires=">=3.8.0,<3.11",


### PR DESCRIPTION
See changelog.

- no longer use explicit submodules unless they're exported
- no longer use pass where it's not needed
- ignore when 3rd party libraries are missing stubs
- for the sake of user experience assume the class is initialized when annotating 
- make the colorama dependency optional (gawd the dependency management is funky)
- allow for unloading miru and stopping all views