### PR TITLE
Adds support for multiple embeds per page in navigator

### DIFF
--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -9,6 +9,7 @@ import hikari
 from miru.abc import Item
 from miru.context import Context
 from miru.view import View
+
 from .items import FirstButton, IndicatorButton, LastButton, NavButton, NavItem, NextButton, PrevButton
 
 logger = logging.getLogger(__name__)
@@ -204,7 +205,10 @@ class NavigatorView(View):
         await context.edit_response(**payload, attachment=None)
 
     async def swap_pages(
-        self, context: Context[t.Any], new_pages: t.Sequence[t.Union[str, hikari.Embed]], start_at: int = 0
+        self,
+        context: Context[t.Any],
+        new_pages: t.Sequence[t.Union[str, hikari.Embed, t.Sequence[hikari.Embed]]],
+        start_at: int = 0,
     ) -> None:
         """Swap out the pages of the navigator to the newly provided pages.
         By default, the navigator will reset to the first page.

--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import logging
 import typing as t
-from collections.abc import Sequence
 
 import hikari
 
@@ -22,7 +21,7 @@ class NavigatorView(View):
 
     Parameters
     ----------
-    pages : List[Union[str, hikari.Embed]]
+    pages : List[Union[str, hikari.Embed, Sequence[hikari.Embed]]]
         A list of strings or embeds that this navigator should paginate.
     buttons : Optional[List[NavButton[NavigatorViewT]]], optional
         A list of navigation buttons to override the default ones with, by default None
@@ -40,7 +39,7 @@ class NavigatorView(View):
     def __init__(
         self,
         *,
-        pages: t.Sequence[t.Union[str, hikari.Embed]],
+        pages: t.Sequence[t.Union[str, hikari.Embed, t.Sequence[hikari.Embed]]],
         buttons: t.Optional[t.Sequence[NavButton]] = None,
         timeout: t.Optional[t.Union[float, int, datetime.timedelta]] = 120.0,
         autodefer: bool = True,
@@ -157,7 +156,7 @@ class NavigatorView(View):
         """Get the page content that is to be sent."""
 
         content = page if isinstance(page, str) else ""
-        if isinstance(page, Sequence):
+        if isinstance(page, t.Sequence):
             embeds = page
         else:
             embeds = [page] if isinstance(page, hikari.Embed) else []
@@ -214,7 +213,7 @@ class NavigatorView(View):
         ----------
         context : Context
             The context object that should be used to send the updated pages
-        new_pages : Sequence[Union[str, Embed]]
+        new_pages : Sequence[Union[str, Embed, Sequence[Embed]]]
             The new pages to swap to
         start_at : int, optional
             The page to start at, by default 0


### PR DESCRIPTION
This is a simple feature request to add support for having multiple embeds on a single page.

This allows you to use navigator when you're using embeds to display specific records in their own embeds and etc., but you have more than 10 results and need to chunk them into pages.