### PR TITLE
Fix paginator IndexError

### DIFF
--- a/miru/ext/nav/utils/paginator.py
+++ b/miru/ext/nav/utils/paginator.py
@@ -38,7 +38,7 @@ class Paginator:
             )
 
         if not self._pages:
-            self._pages[0] = self._prefix
+            self._pages.append(self._prefix)
 
         # If content fits on page
         if not len(self._pages[-1]) + len(f"{line}{self._line_separator}{self._suffix}") >= self._max_len:


### PR DESCRIPTION
Fixed IndexError within the paginator, which will always be raised upon calling add_line for the first element, thus rendering it unusable.